### PR TITLE
fix: Added support for worktrees in detached head states

### DIFF
--- a/lua/worktrees/utils.lua
+++ b/lua/worktrees/utils.lua
@@ -101,6 +101,8 @@ M.get_worktrees = function()
         elseif worktree_data[1] == "branch" then
             local split_path = M.split_string(worktree_data[2], "/")
             branch = split_path[#split_path]
+        elseif worktree_data[1] == "detached" then
+            branch = "detached HEAD"
         elseif worktree_data[1] == "bare" then
             is_bare = true
         end


### PR DESCRIPTION
Started using this plugin and came across an error when running the switch command with the snacks picker integration due to one of my worktrees being in a detached head state due to it having a tag checked out.