### PR TITLE
feat(snacks): add picker for creating a new worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ require("telescope").extensions.worktrees.list_worktrees(opts)
 
 ## Snacks.nvim
 
-Worktrees can also be switched using snacks.nvim
+Worktrees can also be created and switched using snacks.nvim
 
 ```lua
 vim.keymap.set("n", "<leader>gws", function() Snacks.picker.worktrees() end)
+vim.keymap.set("n", "<leader>gwn", function() Snacks.picker.worktrees_new() end)
 ```
 
 ## Troubleshooting

--- a/lua/worktrees/init.lua
+++ b/lua/worktrees/init.lua
@@ -28,12 +28,16 @@ M.setup = function(opts)
     end, { nargs = 0 })
 
     if Snacks and pcall(require, "snacks.picker") then
-        Snacks.picker.sources.worktrees = require("worktrees.snacks")
+        local snacks = require("worktrees.snacks")
+        Snacks.picker.sources.worktrees= snacks.switch
+        Snacks.picker.sources.worktrees_new = snacks.new
     end
 end
 
-M.new_worktree = function(existing_branch)
-    local branch = vim.fn.input("Branch name: ")
+---@param existing_branch? boolean Use existing branch
+---@param branch_name? string Branch name to use. Prompts for the name if not provided
+M.new_worktree = function(existing_branch, branch_name)
+    local branch = branch_name or vim.fn.input("Branch name: ")
     if branch == "" then
         status:warn("No branch name provided. Aborting...")
         return

--- a/lua/worktrees/snacks.lua
+++ b/lua/worktrees/snacks.lua
@@ -1,13 +1,37 @@
 local worktrees = require("worktrees")
 local worktrees_utils = require("worktrees.utils")
 
-local M = {
+---@type snacks.picker.Config
+local New = {
+    title = "New Worktree",
+    finder = "git_branches",
+    format = "git_branch",
+    preview = "git_log",
+}
+
+---@param picker snacks.Picker
+---@param item? snacks.picker.Item
+function New.confirm(picker, item)
+    picker:close()
+
+    local existing_branch = false
+    local branch_name = picker.finder.filter.pattern
+    if item ~= nil then
+        existing_branch = true
+        branch_name = item.file
+    end
+
+    worktrees.new_worktree(existing_branch, branch_name)
+end
+
+---@type snacks.picker.Config
+local Switch = {
+    title = "Worktrees",
     preview = "preview",
 }
 
----@param opts snacks.picker.Config
 ---@type snacks.picker.finder
-function M.finder(opts, filter)
+function Switch.finder(_, _)
     local found_worktrees = worktrees_utils.get_worktrees()
     if found_worktrees == nil then
         found_worktrees = {}
@@ -37,7 +61,7 @@ end
 
 ---@param item snacks.picker.Item
 ---@param picker snacks.Picker
-function M.format(item, picker)
+function Switch.format(item, picker)
     local ret = {} --@type snacks.picker.Highlight[]
     ret[#ret + 1] = { item.branch, "SnacksPickerGitBranch" }
     ret[#ret + 1] = { " " }
@@ -49,7 +73,7 @@ end
 
 ---@param picker snacks.Picker
 ---@param item? snacks.picker.Item
-function M.confirm(picker, item)
+function Switch.confirm(picker, item)
     picker:close()
 
     if item ~= nil then
@@ -57,4 +81,8 @@ function M.confirm(picker, item)
     end
 end
 
-return M
+---@type table<snacks.picker.Config>
+return {
+    new = New,
+    switch = Switch,
+}


### PR DESCRIPTION
I'm not entirely happy how this turned out. It feels wrong to have a separate picker for creating a new worktree instead of it being an action of the same picker. But if there is a way to implement that I couldn't figure it out. The fact that the pickers need different `finder`, `format`, and `preview` also suggest that these need to be separate pickers. As does the fact that `git_log`, `git_log_line`, and `git_log_file` builtin pickers are all separate pickers instead of a configuration option of the same picker.