### PR TITLE
feature: allow customising command to switch directories / files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ require("worktrees").setup({
     log_level = <one of vim.log.levels> -- default: vim.log.levels.WARN,
     log_status = <boolean> -- default: true
     worktree_path = <string> -- default: ".."
-    use_netrw = <boolean> -- default: true
+    switch_file_command  = <string> -- default: Ex
 })
 ```
 
@@ -53,7 +53,7 @@ Path notes:
 - `~` is expanded.
 - Relative paths are resolved against current Neovim `cwd`.
 
-`use_netrw` controls whether to open netrw when switching worktrees or removing worktree and no buffer is available for use
+`switch_file_command` controls what command to use when switching worktrees or removing worktree and no buffer is available for use. Set to nil to disable
 
 ## Usage
 

--- a/lua/worktrees/init.lua
+++ b/lua/worktrees/init.lua
@@ -8,7 +8,7 @@ M._default_options = {
     log_level = vim.log.levels.WARN,
     log_status = true,
     worktree_path = "..",
-    use_netrw = true,
+    switch_file_command = "Ex",
 }
 
 M.setup = function(opts)
@@ -148,7 +148,7 @@ M.switch_worktree = function(path)
         utils.update_current_buffer(
             found_path,
             before_git_path_info,
-            M._options.use_netrw
+            M._options.switch_file_command
         )
         status:info_nvim("Updating buffer")
 
@@ -194,7 +194,7 @@ M.remove_worktree = function(path)
 
             utils.delete_buffers()
 
-            utils.open_netrw_if_enabled(M._options.use_netrw)
+            utils.open_if_enabled(M._options.switch_file_command)
         end)
     end
 

--- a/lua/worktrees/utils.lua
+++ b/lua/worktrees/utils.lua
@@ -153,11 +153,11 @@ M.get_worktrees = function()
     return output
 end
 
-M.update_current_buffer = function(new_cwd, git_path_info, use_netrw)
+M.update_current_buffer = function(new_cwd, git_path_info, switch_file_command)
     -- Check if buffer is a file and cwd is not bare repo
     local buffer_path = Path:new(vim.api.nvim_buf_get_name(0))
     if not buffer_path:is_file() or git_path_info.is_bare_repo then
-        M.open_netrw_if_enabled(use_netrw, new_cwd)
+        M.open_if_enabled(switch_file_command, new_cwd)
         return
     end
 
@@ -173,7 +173,7 @@ M.update_current_buffer = function(new_cwd, git_path_info, use_netrw)
     M.delete_buffers()
 
     if not buffer_path_in_new_cwd:exists() then
-        M.open_netrw_if_enabled(use_netrw, new_cwd)
+        M.open_if_enabled(switch_file_command, new_cwd)
         return
     end
 
@@ -184,9 +184,9 @@ M.update_current_buffer = function(new_cwd, git_path_info, use_netrw)
     end)
 end
 
-M.open_netrw_if_enabled = function(enabled, dir)
-    if enabled then
-        vim.cmd("Ex " .. (dir or ""))
+M.open_if_enabled = function(cmd, dir)
+    if cmd then
+        vim.cmd(cmd .. " " .. (dir or ""))
     end
 end
 


### PR DESCRIPTION
Hi!
Discovered this plugin and I'm having a blast with it, I just found one issue: I'm using [oil.nvim](https://github.com/stevearc/oil.nvim) instead of netrw, so the whole functionality of switching the opened buffer went out the roof. I thought instead of having a boolean for `use_netrw` it would be nice to allow the user to pass the command that should be used to open the file. Lmk what you think, open to any suggestions