### PR TITLE
feature: add hooks to worktree switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ require('worktrees').setup {
                     vim.schedule(function()
                         local buf_in_new_cwd = vim.fn.bufnr(path_in_new_cwd:absolute(), true)
                         vim.api.nvim_win_set_buf(win, buf_in_new_cwd)
+                        vim.api.nvim_buf_delete(bufnr)
                     end)
                 else
                     vim.api.nvim_win_close(win, true)

--- a/README.md
+++ b/README.md
@@ -144,16 +144,24 @@ require('worktrees').setup {
     hooks = {
         on_switch = function(from, to)
             local Path = require 'plenary.path'
+            local any_exist = false
             for win in vim.iter(vim.api.nvim_list_tabpages()):map(vim.api.nvim_tabpage_list_wins):flatten() do
                 local bufnr = vim.api.nvim_win_get_buf(win)
                 local buf_path = Path:new(vim.api.nvim_buf_get_name(bufnr))
                 local rel_path = buf_path:make_relative(from)
                 local path_in_new_cwd = Path:new(to .. '/' .. rel_path)
                 if path_in_new_cwd:exists() then
+                    any_exist = true
                     vim.schedule(function()
                         local buf_in_new_cwd = vim.fn.bufnr(path_in_new_cwd:absolute(), true)
                         vim.api.nvim_win_set_buf(win, buf_in_new_cwd)
                     end)
+                else
+                    vim.api.nvim_win_close(win, true)
+                end
+                if not any_exist then
+                    local root = vim.fn.bufnr(to)
+                    vim.api.nvim_set_current_buf(root)
                 end
             end
         end,

--- a/README.md
+++ b/README.md
@@ -117,6 +117,50 @@ or with lua
 :lua require("worktrees").remove_worktree()
 ```
 
+## Hooks
+
+You can provide hooks to perform additional actions on worktree addition, removal and switching
+```lua
+require('worktrees').setup {
+    hooks = {
+        on_add = function(name, path, branch)
+            -- your action here
+        end,
+        on_switch = function(from, to, git_path_info)
+            -- your action here
+        end,
+        on_remove = function(name)
+            -- your action here
+        end,
+    }
+}
+```
+
+### Example - switch all open buffers to new worktree
+
+```lua
+require('worktrees').setup {
+    swap_current_buffer = false,
+    hooks = {
+        on_switch = function(from, to)
+            local Path = require 'plenary.path'
+            for win in vim.iter(vim.api.nvim_list_tabpages()):map(vim.api.nvim_tabpage_list_wins):flatten() do
+                local bufnr = vim.api.nvim_win_get_buf(win)
+                local buf_path = Path:new(vim.api.nvim_buf_get_name(bufnr))
+                local rel_path = buf_path:make_relative(from)
+                local path_in_new_cwd = Path:new(to .. '/' .. rel_path)
+                if path_in_new_cwd:exists() then
+                    vim.schedule(function()
+                        local buf_in_new_cwd = vim.fn.bufnr(path_in_new_cwd:absolute(), true)
+                        vim.api.nvim_win_set_buf(win, buf_in_new_cwd)
+                    end)
+                end
+            end
+        end,
+    }
+}
+
+```
 ## Telescope
 
 The extension can be loaded with telescope
@@ -154,7 +198,6 @@ require("worktrees").setup({
     log_status = <boolean>, -- default true
 })
 ```
-
 
 ### Upstream setup
 

--- a/lua/worktrees/init.lua
+++ b/lua/worktrees/init.lua
@@ -2,15 +2,33 @@ local jobs = require("worktrees.jobs")
 local utils = require("worktrees.utils")
 local status = require("worktrees.status")
 
-local M = {}
+---@class worktrees.Hooks
+---@field on_switch fun(from: string, to: string, git_path_info: worktrees.GitPathInfo)
+---@field on_add fun(name: string, path: string, branch: string)
+---@field on_remove fun(name: string)
+
+---@class worktrees.Options
+---@field hooks? worktrees.Hooks,
+---@field log_level? vim.log.levels,
+---@field worktree_path? string
+---@field switch_file_command? string
+---@field swap_current_buffer? boolean
+
+local M = {
+    --- @type worktrees.Options
+    _options = {},
+}
 
 M._default_options = {
     log_level = vim.log.levels.WARN,
     log_status = true,
     worktree_path = "..",
     switch_file_command = "Ex",
+    swap_current_buffer = true,
+    hooks = {},
 }
 
+---@param opts worktrees.Options
 M.setup = function(opts)
     local options = opts or {}
     M._options = vim.tbl_deep_extend("force", M._default_options, options)
@@ -86,6 +104,9 @@ M.new_worktree = function(existing_branch, branch_name)
         status:warn("Could not create worktree with arguments. Aborting...")
         return
     end
+    if M._options.hooks.on_add then
+        M._options.hooks.on_add(folder, relative_path, args[#args - 1])
+    end
 
     status:info_nvim("Worktree created")
 
@@ -145,15 +166,27 @@ M.switch_worktree = function(path)
         -- in the jumplist for accidental switching of worktrees
         vim.cmd("clearjumps")
 
-        utils.update_current_buffer(
-            found_path,
-            before_git_path_info,
-            M._options.switch_file_command
-        )
-        status:info_nvim("Updating buffer")
+        if M._options.swap_current_buffer then
+            utils.update_current_buffer(
+                found_path,
+                before_git_path_info,
+                M._options.switch_file_command
+            )
+            status:info_nvim("Updating buffer")
+        end
 
         -- Change neovim cwd
-        vim.cmd("cd " .. found_path)
+        if M._options.hooks.on_switch then
+            local prev_path = vim.loop.cwd() --[[@as string]]
+            vim.cmd("cd " .. found_path)
+            M._options.hooks.on_switch(
+                prev_path,
+                found_path,
+                before_git_path_info
+            )
+        else
+            vim.cmd("cd " .. found_path)
+        end
     end)
 end
 
@@ -211,7 +244,9 @@ M.remove_worktree = function(path)
         status:warn("Could not delete worktree with arguments. Aborting...")
         return
     end
-
+    if M._options.hooks.on_remove then
+        M._options.hooks.on_remove(found_path)
+    end
     status:info_nvim("Worktree removed")
 end
 

--- a/lua/worktrees/utils.lua
+++ b/lua/worktrees/utils.lua
@@ -19,6 +19,11 @@ M.str_to_boolean = function(str)
     return str == "true"
 end
 
+---@class worktrees.GitPathInfo
+---@field is_bare_repo boolean
+---@field toplevel_path? table plenary Path
+
+---@return worktrees.GitPathInfo?
 M.get_git_path_info = function()
     local git_info = {}
 


### PR DESCRIPTION
Like I promised, added a feature to allow users to add hooks that will fire on worktree switch / add / remove.

I am wondering if current `utils.update_current_buffer` logic shouldn't be turned into a "recipe", since it conflicts with custom logic for that (which was the reason I wanted to add that in the first place)

Any and all feedback welcome!