### PR TITLE
feat: add on_before_switch and on_before_remove hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ require('worktrees').setup {
 
 ```
 
-### Example - save worktree session before switch
+### Example - `mini.sessions` integration
 
 ```lua
 require('worktrees').setup {
@@ -183,7 +183,7 @@ require('worktrees').setup {
     hooks = {
         on_before_switch = function(from, to, git_path_info)
             -- Persist worktree session before worktree switch.
-            require('mini.session').write(nil, { force = true, verbose = false })
+            MiniSessions.write(nil, { force = true, verbose = false })
             vim.cmd('silent! %bwipeout!')
 
             -- Prevent dangling LSP sessions.
@@ -195,10 +195,19 @@ require('worktrees').setup {
         end,
         on_switch = function(from, to, git_path_info)
             -- Restore session after worktree changes.
-            if vim.fn.filereadable('Session.vim') then
-              require('mini.session').read(nil, { force = true, verbose = false })
+            if vim.fn.filereadable(MiniSessions.config.file) then
+              MiniSessions.read(nil, { force = true, verbose = false })
             end
         end,
+        on_before_remove = function(path)
+            if path ~= vim.loop.cwd() or vim.v.this_session == '' then
+              return
+            end
+
+            -- Detach session if active worktree will be removed.
+            MiniSessions.delete(nil, { force = true, verbose = false })
+            vim.v.this_session = ''
+        end
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ require('worktrees').setup {
             require('mini.session').write(nil, { force = true, verbose = false })
             vim.cmd('silent! %bwipeout!')
 
+            -- Prevent dangling LSP sessions.
+            vim.lsp.stop_client(vim.lsp.get_clients())
+
             -- Out of the box, worktrees.nvim changes a working directory on worktree switch.
             -- Optionally, you may prevent this by returning "false".
             -- return false

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ require('worktrees').setup {
 
 ```
 
-### Example - `mini.sessions` integration
+### Example - per-worktree sessions using `mini.sessions`
 
 ```lua
 require('worktrees').setup {

--- a/README.md
+++ b/README.md
@@ -120,10 +120,14 @@ or with lua
 ## Hooks
 
 You can provide hooks to perform additional actions on worktree addition, removal and switching
+
 ```lua
 require('worktrees').setup {
     hooks = {
         on_add = function(name, path, branch)
+            -- your action here
+        end,
+        on_before_switch = function(from, to, git_path_info)
             -- your action here
         end,
         on_switch = function(from, to, git_path_info)
@@ -170,6 +174,32 @@ require('worktrees').setup {
 }
 
 ```
+
+### Example - save worktree session before switch
+
+```lua
+require('worktrees').setup {
+    swap_current_buffer = false,
+    hooks = {
+        on_before_switch = function(from, to, git_path_info)
+            -- Persist worktree session before worktree switch.
+            require('mini.session').write(nil, { force = true, verbose = false })
+            vim.cmd('silent! %bwipeout!')
+
+            -- Out of the box, worktrees.nvim changes a working directory on worktree switch.
+            -- Optionally, you may prevent this by returning "false".
+            -- return false
+        end,
+        on_switch = function(from, to, git_path_info)
+            -- Restore session after worktree changes.
+            if vim.fn.filereadable('Session.vim') then
+              require('mini.session').read(nil, { force = true, verbose = false })
+            end
+        end,
+    }
+}
+```
+
 ## Telescope
 
 The extension can be loaded with telescope
@@ -226,4 +256,4 @@ git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 
 ## TODO
 
-- [ ]  Options to customize behavior
+- [ ] Options to customize behavior

--- a/lua/worktrees/init.lua
+++ b/lua/worktrees/init.lua
@@ -6,6 +6,7 @@ local status = require("worktrees.status")
 ---@field on_before_switch fun(from: string, to: string, git_path_info: worktrees.GitPathInfo): boolean | nil
 ---@field on_switch fun(from: string, to: string, git_path_info: worktrees.GitPathInfo)
 ---@field on_add fun(name: string, path: string, branch: string)
+---@field on_before_remove fun(path: string) | nil
 ---@field on_remove fun(name: string)
 
 ---@class worktrees.Options
@@ -223,6 +224,10 @@ M.remove_worktree = function(path)
     if found_path == nil then
         status:warn("Could not determine path to remove. Aborting...")
         return
+    end
+
+    if M._options.hooks.on_before_remove then
+        M._options.hooks.on_before_remove(found_path)
     end
 
     if found_path == vim.loop.cwd() then

--- a/lua/worktrees/init.lua
+++ b/lua/worktrees/init.lua
@@ -3,6 +3,7 @@ local utils = require("worktrees.utils")
 local status = require("worktrees.status")
 
 ---@class worktrees.Hooks
+---@field on_before_switch fun(from: string, to: string, git_path_info: worktrees.GitPathInfo): boolean | nil
 ---@field on_switch fun(from: string, to: string, git_path_info: worktrees.GitPathInfo)
 ---@field on_add fun(name: string, path: string, branch: string)
 ---@field on_remove fun(name: string)
@@ -162,6 +163,20 @@ M.switch_worktree = function(path)
     end
 
     vim.schedule(function()
+        local prev_path = vim.loop.cwd() --[[@as string]]
+
+        if M._options.hooks.on_before_switch then
+            -- on_before_switch can intercept worktree switch logic if returns 'false'.
+            local continue = M._options.hooks.on_before_switch(
+                prev_path,
+                found_path,
+                before_git_path_info
+            )
+            if continue ~= nil and not continue then
+                return
+            end
+        end
+
         -- Clear jumplist so that no file in the old worktree is present
         -- in the jumplist for accidental switching of worktrees
         vim.cmd("clearjumps")
@@ -177,7 +192,6 @@ M.switch_worktree = function(path)
 
         -- Change neovim cwd
         if M._options.hooks.on_switch then
-            local prev_path = vim.loop.cwd() --[[@as string]]
             vim.cmd("cd " .. found_path)
             M._options.hooks.on_switch(
                 prev_path,

--- a/lua/worktrees/init.lua
+++ b/lua/worktrees/init.lua
@@ -5,9 +5,9 @@ local status = require("worktrees.status")
 ---@class worktrees.Hooks
 ---@field on_before_switch fun(from: string, to: string, git_path_info: worktrees.GitPathInfo): boolean | nil
 ---@field on_switch fun(from: string, to: string, git_path_info: worktrees.GitPathInfo)
----@field on_add fun(name: string, path: string, branch: string)
+---@field on_add fun(name: string, path: string, branch: string) | nil
 ---@field on_before_remove fun(path: string) | nil
----@field on_remove fun(name: string)
+---@field on_remove fun(name: string) | nil
 
 ---@class worktrees.Options
 ---@field hooks? worktrees.Hooks,


### PR DESCRIPTION
This PR adds several new hooks:

* `on_before_switch` - runs before a worktree switch is completed.
* `on_before_remove` - runs before a worktree is being deleted.

These hooks allows to implement features like session persistence and overriding worktree switch process.

Closes #10 